### PR TITLE
Changed process order to find Credentials

### DIFF
--- a/paste.go
+++ b/paste.go
@@ -35,7 +35,7 @@ func (p *Paste) Download() {
 
 func (p *Paste) Process() {
 	// Find and save specific data.
-	if processEmails(p.Content, p.Key) || processCredentials(p.Content, p.Key) ||
+	if processCredentials(p.Content, p.Key) || processEmails(p.Content, p.Key) ||
 		processPrivKey(p.Content, p.Key) || processAWSKeys(p.Content, p.Key) {
 		conf.ds.Put("rawpastes", p.Key, p)
 	}


### PR DESCRIPTION
Credentials were never found because the Email address was found first. Now Searching for Credentials first finds them if they exist.